### PR TITLE
build: Upgrade to Zig 0.15.1

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Setup Zig
-        uses: mlugg/setup-zig@v1
+        uses: mlugg/setup-zig@v2.0.5
         with:
           version: 0.15.1
       - name: Checkout

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Zig
         uses: mlugg/setup-zig@v1
         with:
-          version: 0.14.0
+          version: 0.15.1
       - name: Checkout
         uses: actions/checkout@v4
       - name: Test

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Setup Zig
         uses: mlugg/setup-zig@v1
         with:
-          version: 0.14.0
+          version: 0.15.1
       - name: Checkout
         uses: actions/checkout@v4
       - name: Setup Pages

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Setup Zig
-        uses: mlugg/setup-zig@v1
+        uses: mlugg/setup-zig@v2.0.5
         with:
           version: 0.15.1
       - name: Checkout

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -2,7 +2,7 @@
     .name = .zterm,
     .version = "0.14.4",
     .fingerprint = 0xf10b37e2675fe36e,
-    .minimum_zig_version = "0.14.0",
+    .minimum_zig_version = "0.15.1",
 
     .paths = .{
         "build.zig",

--- a/src/attr.zig
+++ b/src/attr.zig
@@ -64,14 +64,14 @@ pub const Style = struct {
     pub const default = new();
     pub const none = default;
 
-    pub fn fprint(self: Self, w: anytype, comptime fmt: []const u8, args: anytype) @TypeOf(w).Error!void {
+    pub fn fprint(self: Self, w: *std.io.Writer, comptime fmt: []const u8, args: anytype) std.io.Writer.Error!void {
         try self.stringifyEnv(w);
         try std.fmt.format(w, fmt, args);
     }
-    pub fn format(self: Self, comptime _: []const u8, _: FormatOptions, w: anytype) @TypeOf(w).Error!void {
+    pub fn format(self: Self, w: *std.io.Writer) std.io.Writer.Error!void {
         try self.stringifyEnv(w);
     }
-    pub fn stringify(self: Self, w: anytype) @TypeOf(w).Error!void {
+    pub fn stringify(self: Self, w: *std.io.Writer) std.io.Writer.Error!void {
         try self.stringifyCSI(w, true);
     }
     pub fn toString(self: Self) *const [helper.stringify(self).count():0]u8 {
@@ -110,7 +110,7 @@ pub const Style = struct {
             forceNoStyle(false);
             try testing.expectEqualStrings(
                 "\x1b[0;1mhello\x1b[0m",
-                try sprint(&buffer, "{s}", .{new().set(.bold).value("hello")}),
+                try sprint(&buffer, "{f}", .{std.fmt.alt(new().set(.bold).value("hello"), .formatString)}),
             );
             try testing.expectEqualStrings(
                 "\x1b[0;1mcc\x1b[0m",
@@ -136,7 +136,7 @@ pub const Style = struct {
         unreachable;
     }
 
-    fn stringifyCSI(self: Self, w: anytype, csi: bool) @TypeOf(w).Error!void {
+    fn stringifyCSI(self: Self, w: *std.io.Writer, csi: bool) std.io.Writer.Error!void {
         var first = true;
         if (self.flag_strict) {
             if (csi) try formatAny(ctl.ESCSequence.CSI, w);
@@ -154,7 +154,7 @@ pub const Style = struct {
         }
         if (csi and !first) try formatAny(ctl.CSISequenceFunction.SGR, w);
     }
-    fn stringifyEnv(self: Self, w: anytype) @TypeOf(w).Error!void {
+    fn stringifyEnv(self: Self, w: *std.io.Writer) std.io.Writer.Error!void {
         if (Flag(.NO_STYLE).check()) return;
         try self.stringify(w);
     }
@@ -223,14 +223,14 @@ pub const Color = struct {
         return colorHex(c);
     }
 
-    pub fn fprint(self: Self, w: anytype, comptime fmt: []const u8, args: anytype) @TypeOf(w).Error!void {
+    pub fn fprint(self: Self, w: *std.io.Writer, comptime fmt: []const u8, args: anytype) std.io.Writer.Error!void {
         try self.stringifyEnv(w);
         try std.fmt.format(w, fmt, args);
     }
-    pub fn format(self: Self, comptime _: []const u8, _: FormatOptions, w: anytype) @TypeOf(w).Error!void {
+    pub fn format(self: Self, w: *std.io.Writer) std.io.Writer.Error!void {
         try self.stringifyEnv(w);
     }
-    pub fn stringify(self: Self, w: anytype) @TypeOf(w).Error!void {
+    pub fn stringify(self: Self, w: *std.io.Writer) std.io.Writer.Error!void {
         try self.stringifyCSI(w, true);
     }
     pub fn toString(self: Self) *const [helper.stringify(self).count():0]u8 {
@@ -273,8 +273,8 @@ pub const Color = struct {
                 "\x1b[0;38;2;1;2;3mhello\x1b[0m",
                 try sprint(
                     &buffer,
-                    "{s}",
-                    .{(colorHexS("#010203") catch unreachable).value("hello")},
+                    "{f}",
+                    .{std.fmt.alt((colorHexS("#010203") catch unreachable).value("hello"), .formatString)},
                 ),
             );
             try testing.expectEqualStrings(
@@ -284,7 +284,7 @@ pub const Color = struct {
         }
     };
 
-    fn stringifyCSI(self: Self, w: anytype, csi: bool) @TypeOf(w).Error!void {
+    fn stringifyCSI(self: Self, w: *std.io.Writer, csi: bool) std.io.Writer.Error!void {
         if (csi) try formatAny(ctl.ESCSequence.CSI, w);
         if (self.flag_strict) {
             try formatInt(SGR.reset, w);
@@ -311,7 +311,7 @@ pub const Color = struct {
         }
         if (csi) try formatAny(ctl.CSISequenceFunction.SGR, w);
     }
-    fn stringifyEnv(self: Self, w: anytype) @TypeOf(w).Error!void {
+    fn stringifyEnv(self: Self, w: *std.io.Writer) std.io.Writer.Error!void {
         if (Flag(.NO_COLOR).check()) return;
         try self.stringify(w);
     }
@@ -357,14 +357,14 @@ pub const Attribute = struct {
         return self.field_set(@src().fn_name, v.bg());
     }
 
-    pub fn fprint(self: Self, w: anytype, comptime fmt: []const u8, args: anytype) @TypeOf(w).Error!void {
+    pub fn fprint(self: Self, w: *std.io.Writer, comptime fmt: []const u8, args: anytype) std.io.Writer.Error!void {
         try self.stringifyEnv(w);
-        try std.fmt.format(w, fmt, args);
+        try w.print(fmt, args);
     }
-    pub fn format(self: Self, comptime _: []const u8, _: FormatOptions, w: anytype) @TypeOf(w).Error!void {
+    pub fn format(self: Self, w: *std.io.Writer) std.io.Writer.Error!void {
         try self.stringifyEnv(w);
     }
-    pub fn stringify(self: Self, w: anytype) @TypeOf(w).Error!void {
+    pub fn stringify(self: Self, w: *std.io.Writer) std.io.Writer.Error!void {
         try self.stringifyCSI(w, true);
     }
     pub fn toString(self: Self) *const [helper.stringify(self).count():0]u8 {
@@ -518,8 +518,8 @@ pub const Attribute = struct {
                 forceNoColor(false);
                 forceNoStyle(true);
                 try testing.expectEqualStrings(
-                    try sprint(&buffer0, "{}", .{new().colorRGB(1, 2, 3).bold()}),
-                    try sprint(&buffer1, "{}", .{new().colorRGB(1, 2, 3).italic()}),
+                    try sprint(&buffer0, "{f}", .{new().colorRGB(1, 2, 3).bold()}),
+                    try sprint(&buffer1, "{f}", .{new().colorRGB(1, 2, 3).italic()}),
                 );
             }
         }
@@ -531,7 +531,7 @@ pub const Attribute = struct {
             forceNoStyle(false);
             try testing.expectEqualStrings(
                 "\x1b[0;1;21;32;47mhello\x1b[0m",
-                try sprint(&buffer, "{s}", .{attr.value("hello")}),
+                try sprint(&buffer, "{f}", .{std.fmt.alt(attr.value("hello"), .formatString)}),
             );
             try testing.expectEqualStrings(
                 "\x1b[0;1;21;32;47m00c1\x1b[0m",
@@ -539,7 +539,7 @@ pub const Attribute = struct {
             );
             try testing.expectEqualStrings(
                 "\x1b[0;1;21;32;47mtrue\x1b[0m",
-                try sprint(&buffer, "{}", .{attr.value(true)}),
+                try sprint(&buffer, "{f}", .{attr.value(true)}),
             );
         }
         test "Attribute Writer" {
@@ -547,8 +547,8 @@ pub const Attribute = struct {
             var buffer = std.mem.zeroes([512]u8);
             forceNoColor(false);
             forceNoStyle(false);
-            var bs = std.io.fixedBufferStream(&buffer);
-            try attr.fprint(bs.writer(), "string {s} int {d}", .{ "hello", 6 });
+            var bs = std.Io.Writer.fixed(&buffer);
+            try attr.fprint(&bs, "string {s} int {d}", .{ "hello", 6 });
             try testing.expectEqualStrings(
                 "\x1b[1;21;32;47mstring hello int 6",
                 std.mem.sliceTo(&buffer, 0),
@@ -573,7 +573,7 @@ pub const Attribute = struct {
         return self.color8(c);
     }
 
-    fn stringifyCSI(self: Self, w: anytype, csi: bool) @TypeOf(w).Error!void {
+    fn stringifyCSI(self: Self, w: *std.Io.Writer, csi: bool) std.Io.Writer.Error!void {
         var first = true;
         if (self.flag_strict) {
             if (csi) try formatAny(ctl.ESCSequence.CSI, w);
@@ -592,7 +592,7 @@ pub const Attribute = struct {
         }
         if (csi and !first) try formatAny(ctl.CSISequenceFunction.SGR, w);
     }
-    fn stringifyEnv(self: Self, w: anytype) @TypeOf(w).Error!void {
+    fn stringifyEnv(self: Self, w: *std.Io.Writer) std.Io.Writer.Error!void {
         if (Flag(.NO_COLOR).check() and Flag(.NO_STYLE).check())
             return;
         var obj = self;
@@ -617,10 +617,65 @@ pub fn Value(A: type, V: type) type {
             return .{ .a = attr.strict(), .v = value };
         }
 
-        pub fn format(self: Self, comptime fmt: []const u8, options: FormatOptions, w: anytype) @TypeOf(w).Error!void {
-            try self.a.stringifyEnv(w);
-            try std.fmt.formatType(self.v, fmt, options, w, std.fmt.default_max_depth);
-            try Attribute.reset.stringifyEnv(w);
+        pub fn format(self: Self, writer: *std.io.Writer) std.io.Writer.Error!void {
+            try self.a.stringifyEnv(writer);
+            try writer.printValue("", .{}, self.v, std.fmt.default_max_depth);
+            try Attribute.reset.stringifyEnv(writer);
+        }
+
+        pub fn formatNumber(self: Self, writer: *std.io.Writer, number: std.fmt.Number) std.io.Writer.Error!void {
+            const options: std.fmt.Options = .{
+                .alignment = number.alignment,
+                .fill = number.fill,
+                .precision = number.precision,
+                .width = number.width,
+            };
+            try self.a.stringifyEnv(writer);
+            switch (number.mode) {
+                .decimal => switch (@typeInfo(@TypeOf(self.v))) {
+                    .float, .comptime_float, .int, .comptime_int, .@"struct", .@"enum", .vector => {
+                        try writer.printValue("d", options, self.v, std.fmt.default_max_depth);
+                    },
+                    else => unreachable,
+                },
+                .binary => switch (@typeInfo(@TypeOf(self.v))) {
+                    .int, .comptime_int, .@"enum", .@"struct", .vector => {
+                        try writer.printValue("b", options, self.v, std.fmt.default_max_depth);
+                    },
+                    else => unreachable,
+                },
+                .octal => switch (@typeInfo(@TypeOf(self.v))) {
+                    .int, .comptime_int, .@"enum", .@"struct", .vector => {
+                        try writer.printValue("o", options, self.v, std.fmt.default_max_depth);
+                    },
+                    else => unreachable,
+                },
+                .hex => switch (@typeInfo(@TypeOf(self.v))) {
+                    .float, .comptime_float, .int, .comptime_int, .@"enum", .@"struct", .pointer, .array, .vector => {
+                        switch (number.case) {
+                            .lower => try writer.printValue("x", options, self.v, std.fmt.default_max_depth),
+                            .upper => try writer.printValue("X", options, self.v, std.fmt.default_max_depth),
+                        }
+                    },
+                    else => unreachable,
+                },
+                .scientific => switch (@typeInfo(@TypeOf(self.v))) {
+                    .float, .comptime_float, .@"struct" => {
+                        switch (number.case) {
+                            .lower => try writer.printValue("e", options, self.v, std.fmt.default_max_depth),
+                            .upper => try writer.printValue("E", options, self.v, std.fmt.default_max_depth),
+                        }
+                    },
+                    else => unreachable,
+                },
+            }
+            try Attribute.reset.stringifyEnv(writer);
+        }
+
+        pub fn formatString(self: Self, writer: *std.io.Writer) std.io.Writer.Error!void {
+            try self.a.stringifyEnv(writer);
+            try writer.alignBufferOptions(self.v, .{});
+            try Attribute.reset.stringifyEnv(writer);
         }
     };
 }

--- a/src/helper.zig
+++ b/src/helper.zig
@@ -12,20 +12,38 @@ const String = alias.String;
 
 pub const formatter = struct {
     const assert = std.debug.assert;
-    pub fn any(v: anytype, writer: anytype) @TypeOf(writer).Error!void {
-        return std.fmt.formatType(v, "any", .{}, writer, std.fmt.default_max_depth);
+    pub fn any(v: anytype, writer: *std.io.Writer) std.io.Writer.Error!void {
+        const actual_fmt = switch (@typeInfo(@TypeOf(v))) {
+            .array, .vector, .optional, .error_union => "any",
+            .pointer => |ptr_info| switch (ptr_info.size) {
+                .one => switch (@typeInfo(ptr_info.child)) {
+                    .array => "any",
+                    else => "",
+                },
+                .many, .c => "*",
+                .slice => "any",
+            },
+            else => "",
+        };
+        if (comptime std.mem.eql(u8, actual_fmt, "*")) {
+            return writer.printAddress(v, .{});
+        }
+        if (std.meta.hasMethod(@TypeOf(v), "format")) {
+            return try v.format(writer);
+        }
+        return writer.printValue(actual_fmt, .{}, v, std.fmt.default_max_depth);
     }
-    pub fn dInt(v: anytype, writer: anytype) @TypeOf(writer).Error!void {
+    pub fn dInt(v: anytype, writer: *std.io.Writer) std.io.Writer.Error!void {
         assert(@typeInfo(@TypeOf(v)) == .int);
-        return std.fmt.formatIntValue(v, "d", .{}, writer);
+        return writer.printIntAny(v, 10, .lower, .{});
     }
-    pub fn dEnum(v: anytype, writer: anytype) @TypeOf(writer).Error!void {
+    pub fn dEnum(v: anytype, writer: *std.io.Writer) std.io.Writer.Error!void {
         assert(@typeInfo(@TypeOf(v)) == .@"enum");
         return dInt(@intFromEnum(v), writer);
     }
-    pub fn cEnum(v: anytype, writer: anytype) @TypeOf(writer).Error!void {
+    pub fn cEnum(v: anytype, writer: *std.io.Writer) std.io.Writer.Error!void {
         assert(@typeInfo(@TypeOf(v)) == .@"enum");
-        return std.fmt.formatIntValue(@intFromEnum(v), "c", .{}, writer);
+        return writer.printAsciiChar(@intFromEnum(v), .{});
     }
     pub fn Raw(T: type) type {
         return struct {
@@ -83,17 +101,17 @@ pub fn Stringify(V: type) type {
         v: V,
         const Self = @This();
         pub fn count(self: Self) usize {
-            var writer = std.io.countingWriter(std.io.null_writer);
+            var counting = std.Io.Writer.Discarding.init(&@as([0]u8, .{}));
             @setEvalBranchQuota(100000); // TODO why?
-            self.v.stringify(writer.writer()) catch unreachable;
-            return writer.bytes_written;
+            self.v.stringify(&counting.writer) catch unreachable;
+            return counting.fullCount();
         }
         pub inline fn literal(self: Self) *const [self.count():0]u8 {
             comptime {
                 var buf: [self.count():0]u8 = undefined;
-                var fbs = std.io.fixedBufferStream(&buf);
+                var fbs = std.Io.Writer.fixed(&buf);
                 @setEvalBranchQuota(100000); // TODO why?
-                self.v.stringify(fbs.writer()) catch unreachable;
+                self.v.stringify(&fbs) catch unreachable;
                 buf[buf.len] = 0;
                 const final = buf;
                 return &final;

--- a/src/mapping/control.zig
+++ b/src/mapping/control.zig
@@ -35,7 +35,7 @@ pub const ControlCharater = enum(u8) {
     /// is equivalent to `ESC [`
     CSI = 0x9B,
 
-    pub fn format(self: Self, comptime _: []const u8, _: FormatOptions, writer: anytype) @TypeOf(writer).Error!void {
+    pub fn format(self: Self, writer: *std.Io.Writer) std.Io.Writer.Error!void {
         return writer.writeByte(@intFromEnum(self));
     }
 
@@ -45,8 +45,8 @@ pub const ControlCharater = enum(u8) {
         test ControlCharater {
             try testing.expectEqual(0x0F, @intFromEnum(ControlCharater.SI));
             try testing.expectEqual(0x1B, @intFromEnum(ControlCharater.ESC));
-            try testing.expectEqualStrings("\x1b", print("{}", .{Self.ESC}));
-            try testing.expectEqualStrings("\x9b", print("{}", .{Self.CSI}));
+            try testing.expectEqualStrings("\x1b", print("{f}", .{Self.ESC}));
+            try testing.expectEqualStrings("\x9b", print("{f}", .{Self.CSI}));
         }
     };
 };
@@ -77,7 +77,7 @@ pub const ESCSequence = enum(u8) {
     /// Control Sequence Introducer
     CSI = '[',
 
-    pub fn format(self: ESCSequence, comptime _: []const u8, _: FormatOptions, writer: anytype) @TypeOf(writer).Error!void {
+    pub fn format(self: ESCSequence, writer: *std.Io.Writer) std.Io.Writer.Error!void {
         try formatter.any(ControlCharater.ESC, writer);
         return formatter.cEnum(self, writer);
     }
@@ -94,7 +94,7 @@ pub const ESCSequence = enum(u8) {
         /// Select UTF-8 (obsolete)
         UTF8_Obsolete = '8',
 
-        pub fn format(self: Self, comptime _: []const u8, _: FormatOptions, writer: anytype) @TypeOf(writer).Error!void {
+        pub fn format(self: Self, writer: *std.Io.Writer) std.Io.Writer.Error!void {
             return format_with_pre(self, Self.pre, writer);
         }
     };
@@ -106,7 +106,7 @@ pub const ESCSequence = enum(u8) {
         /// DEC screen alignment test - fill screen with E's
         DECALN = '8',
 
-        pub fn format(self: Self, comptime _: []const u8, _: FormatOptions, writer: anytype) @TypeOf(writer).Error!void {
+        pub fn format(self: Self, writer: *std.Io.Writer) std.Io.Writer.Error!void {
             return format_with_pre(self, Self.pre, writer);
         }
     };
@@ -124,7 +124,7 @@ pub const ESCSequence = enum(u8) {
         /// Set palette, with parameter given in 7 hexadecimal digits nrrggbb after the final P. Here n is the color (0–15), and rrggbb indicates the red/green/blue values (0–255)
         Set = 'P',
 
-        pub fn format(self: Self, comptime _: []const u8, _: FormatOptions, writer: anytype) @TypeOf(writer).Error!void {
+        pub fn format(self: Self, writer: *std.Io.Writer) std.Io.Writer.Error!void {
             return format_with_pre(self, Self.pre, writer);
         }
     };
@@ -143,12 +143,12 @@ pub const ESCSequence = enum(u8) {
             /// Select user mapping - the map that is loaded by the utility mapscrn(8)
             User = 'K',
 
-            pub fn format(self: Self, comptime _: []const u8, _: FormatOptions, writer: anytype) @TypeOf(writer).Error!void {
+            pub fn format(self: Self, writer: *std.Io.Writer) std.Io.Writer.Error!void {
                 return format_with_pre(self, Self.pre, writer);
             }
         };
     }
-    fn format_with_pre(v: anytype, pre: u8, writer: anytype) @TypeOf(writer).Error!void {
+    fn format_with_pre(v: anytype, pre: u8, writer: *std.Io.Writer) std.Io.Writer.Error!void {
         try formatter.any(ControlCharater.ESC, writer);
         try writer.writeByte(pre);
         return formatter.cEnum(v, writer);
@@ -159,26 +159,26 @@ pub const ESCSequence = enum(u8) {
         const print = alias.print;
         test ESCSequence {
             try testing.expectEqual(']', @intFromEnum(ESCSequence.OSC));
-            try testing.expectEqualStrings("\x1b]", print("{}", .{ESCSequence.OSC}));
-            try testing.expectEqualStrings("\x1b[", print("{}", .{ESCSequence.CSI}));
+            try testing.expectEqualStrings("\x1b]", print("{f}", .{ESCSequence.OSC}));
+            try testing.expectEqualStrings("\x1b[", print("{f}", .{ESCSequence.CSI}));
         }
         test SelectCharSet {
             try testing.expectEqual('@', @intFromEnum(SelectCharSet.Default));
-            try testing.expectEqualStrings("\x1b%@", print("{}", .{SelectCharSet.Default}));
+            try testing.expectEqualStrings("\x1b%@", print("{f}", .{SelectCharSet.Default}));
         }
         test ScreenAlignTest {
             try testing.expectEqual('8', @intFromEnum(ScreenAlignTest.DECALN));
-            try testing.expectEqualStrings("\x1b#8", print("{}", .{ScreenAlignTest.DECALN}));
+            try testing.expectEqualStrings("\x1b#8", print("{f}", .{ScreenAlignTest.DECALN}));
         }
         test DefGxCharSet {
             try testing.expectEqual('B', @intFromEnum(DefG0CharSet.Default));
-            try testing.expectEqualStrings("\x1b(B", print("{}", .{DefG0CharSet.Default}));
+            try testing.expectEqualStrings("\x1b(B", print("{f}", .{DefG0CharSet.Default}));
             try testing.expectEqual('B', @intFromEnum(DefG1CharSet.Default));
-            try testing.expectEqualStrings("\x1b)B", print("{}", .{DefG1CharSet.Default}));
+            try testing.expectEqualStrings("\x1b)B", print("{f}", .{DefG1CharSet.Default}));
         }
         test Palette {
             try testing.expectEqual('R', @intFromEnum(Palette.Reset));
-            try testing.expectEqualStrings("\x1b]R", print("{}", .{Palette.Reset}));
+            try testing.expectEqualStrings("\x1b]R", print("{f}", .{Palette.Reset}));
         }
     };
 };
@@ -248,10 +248,10 @@ pub const CSISequenceFunction = enum(u8) {
     /// Move cursor to indicated column in current row
     HPA = '`',
 
-    pub fn format(self: Self, comptime _: []const u8, _: FormatOptions, writer: anytype) @TypeOf(writer).Error!void {
+    pub fn format(self: Self, writer: *std.Io.Writer) std.Io.Writer.Error!void {
         return formatter.cEnum(self, writer);
     }
-    pub fn param(self: Self, writer: anytype, comptime fmt: []const u8, args: anytype) @TypeOf(writer).Error!void {
+    pub fn param(self: Self, writer: *std.Io.Writer, comptime fmt: []const u8, args: anytype) std.Io.Writer.Error!void {
         try formatter.any(ESCSequence.CSI, writer);
         try writer.print(fmt, args);
         try formatter.any(self, writer);
@@ -262,7 +262,7 @@ pub const CSISequenceFunction = enum(u8) {
         const print = alias.print;
         test CSISequenceFunction {
             try testing.expectEqual('m', @intFromEnum(Self.SGR));
-            try testing.expectEqualStrings("m", print("{}", .{Self.SGR}));
+            try testing.expectEqualStrings("m", print("{f}", .{Self.SGR}));
         }
     };
 };

--- a/src/mapping/parameter.zig
+++ b/src/mapping/parameter.zig
@@ -95,7 +95,7 @@ pub const SGR = struct {
 
                 c: u8,
 
-                pub fn format(self: Self, comptime _: []const u8, _: alias.FormatOptions, writer: anytype) @TypeOf(writer).Error!void {
+                pub fn format(self: Self, writer: *std.io.Writer) std.io.Writer.Error!void {
                     try formatInt(Self.pre, writer);
                     try writer.writeByte(sep);
                     return formatInt(self.c, writer);
@@ -105,9 +105,9 @@ pub const SGR = struct {
                     const testing = std.testing;
                     const print = alias.print;
                     test Color256 {
-                        try testing.expectEqualStrings("5;66", print("{}", .{Self{ .c = 66 }}));
-                        try testing.expectEqualStrings("5;12", print("{}", .{Self{ .c = @intFromEnum(IBGR.blue) }}));
-                        try testing.expectEqualStrings("5;241", print("{}", .{Self{ .c = @intFromEnum(Grayscale.grey39) }}));
+                        try testing.expectEqualStrings("5;66", print("{f}", .{Self{ .c = 66 }}));
+                        try testing.expectEqualStrings("5;12", print("{f}", .{Self{ .c = @intFromEnum(IBGR.blue) }}));
+                        try testing.expectEqualStrings("5;241", print("{f}", .{Self{ .c = @intFromEnum(Grayscale.grey39) }}));
                     }
                 };
             };
@@ -120,7 +120,7 @@ pub const SGR = struct {
                 g: u8,
                 b: u8,
 
-                pub fn format(self: Self, comptime _: []const u8, _: alias.FormatOptions, writer: anytype) @TypeOf(writer).Error!void {
+                pub fn format(self: Self, writer: *std.io.Writer) std.io.Writer.Error!void {
                     try formatInt(Self.pre, writer);
                     try writer.writeByte(sep);
                     try formatInt(self.r, writer);
@@ -134,7 +134,7 @@ pub const SGR = struct {
                     const testing = std.testing;
                     const print = alias.print;
                     test ColorRGB {
-                        try testing.expectEqualStrings("2;1;2;3", print("{}", .{Self{ .r = 1, .g = 2, .b = 3 }}));
+                        try testing.expectEqualStrings("2;1;2;3", print("{f}", .{Self{ .r = 1, .g = 2, .b = 3 }}));
                     }
                 };
             };


### PR DESCRIPTION
Currently all tests pass.
The purpose of this update is just to make sure all test cases pass under zig 0.15.1, so it is not a comprehensive update, for example `formatByteSize` and `formatDuration` are not implemented.